### PR TITLE
Fix building unit tests with gcc 12 or newer

### DIFF
--- a/tests/ut_mcalendar/ut_mcalendar.cpp
+++ b/tests/ut_mcalendar/ut_mcalendar.cpp
@@ -2659,9 +2659,9 @@ void Ut_MCalendar::testMLocaleCalendarConversionsFromMCalendar()
                 expectedResult = dateResults[dateType] + ", " + timeResults[timeType];
             else if(locale.categoryName(MLocale::MLcTime).startsWith("fa_IR")) {
                 if (dateType == MLocale::DateShort || dateType == MLocale::DateMedium)
-                        expectedResult = "‫" + dateResults[dateType] + "،‏ " + timeResults[timeType] + "‬";
+                        expectedResult = QChar(0x202B) + dateResults[dateType] + "،‏ " + timeResults[timeType] + QChar(0x202C);
                     else
-                        expectedResult = "‫" + dateResults[dateType] + "، ساعت " + timeResults[timeType]  + "‬";
+                        expectedResult = QChar(0x202B) + dateResults[dateType] + "، ساعت " + timeResults[timeType]  + QChar(0x202C);
             }
             else if(locale.categoryName(MLocale::MLcTime).startsWith("vi")) {
                 expectedResult = timeResults[timeType] + " " + dateResults[dateType];


### PR DESCRIPTION
New gcc is more strict about bi-directional control characters so let's make those QChars instead of using simple strings.